### PR TITLE
Add frontend skeleton

### DIFF
--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import AppNavigator from './navigation/AppNavigator';
+
+export default function App() {
+  return <AppNavigator />;
+}

--- a/frontend/components/PointGraph.js
+++ b/frontend/components/PointGraph.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function PointGraph({ data }) {
+  return (
+    <View>
+      <Text>PointGraph Placeholder</Text>
+    </View>
+  );
+}

--- a/frontend/components/RewardItem.js
+++ b/frontend/components/RewardItem.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function RewardItem({ reward }) {
+  return (
+    <View>
+      <Text>RewardItem Placeholder</Text>
+    </View>
+  );
+}

--- a/frontend/components/TaskCard.js
+++ b/frontend/components/TaskCard.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function TaskCard({ task }) {
+  return (
+    <View>
+      <Text>TaskCard Placeholder</Text>
+    </View>
+  );
+}

--- a/frontend/navigation/AppNavigator.js
+++ b/frontend/navigation/AppNavigator.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function AppNavigator() {
+  return (
+    <View>
+      <Text>App Navigator</Text>
+    </View>
+  );
+}

--- a/frontend/screens/ChallengeScreen.js
+++ b/frontend/screens/ChallengeScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function ChallengeScreen() {
+  return (
+    <View>
+      <Text>ChallengeScreen</Text>
+    </View>
+  );
+}

--- a/frontend/screens/HomeScreen.js
+++ b/frontend/screens/HomeScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <View>
+      <Text>HomeScreen</Text>
+    </View>
+  );
+}

--- a/frontend/screens/LeaderboardScreen.js
+++ b/frontend/screens/LeaderboardScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function LeaderboardScreen() {
+  return (
+    <View>
+      <Text>LeaderboardScreen</Text>
+    </View>
+  );
+}

--- a/frontend/screens/LoginScreen.js
+++ b/frontend/screens/LoginScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function LoginScreen() {
+  return (
+    <View>
+      <Text>LoginScreen</Text>
+    </View>
+  );
+}

--- a/frontend/screens/TaskScreen.js
+++ b/frontend/screens/TaskScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function TaskScreen() {
+  return (
+    <View>
+      <Text>TaskScreen</Text>
+    </View>
+  );
+}

--- a/frontend/services/api.js
+++ b/frontend/services/api.js
@@ -1,0 +1,7 @@
+export async function fetchFromApi(endpoint, options = {}) {
+  const response = await fetch(endpoint, options);
+  if (!response.ok) {
+    throw new Error('API request failed');
+  }
+  return response.json();
+}

--- a/frontend/utils/auth.js
+++ b/frontend/utils/auth.js
@@ -1,0 +1,9 @@
+let token = null;
+
+export function setToken(newToken) {
+  token = newToken;
+}
+
+export function getToken() {
+  return token;
+}


### PR DESCRIPTION
## Summary
- create `frontend` folder with React skeleton structure
- add navigation and screen placeholders
- add reusable components and service helpers
- implement basic auth utility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870e401e4b4832e9d59efd5501061d0