### PR TITLE
Fix JPA mappings for Challenge participants

### DIFF
--- a/ESB-APP/src/main/java/com/esb/esbapp/model/Task.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/model/Task.java
@@ -2,6 +2,8 @@ package com.esb.esbapp.model;
 
 import jakarta.persistence.*;
 
+import com.esb.esbapp.model.Challenge;
+
 @Entity
 @Table(name = "tasks")
 public class Task {
@@ -19,6 +21,10 @@ public class Task {
     private Integer points;
 
     private Boolean enabled = true;
+
+    @ManyToOne
+    @JoinColumn(name = "challenge_id")
+    private Challenge challenge;
 
     public Task() {
     }
@@ -78,5 +84,13 @@ public class Task {
 
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public Challenge getChallenge() {
+        return challenge;
+    }
+
+    public void setChallenge(Challenge challenge) {
+        this.challenge = challenge;
     }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/model/User.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/model/User.java
@@ -1,6 +1,9 @@
 package com.esb.esbapp.model;
 
 import jakarta.persistence.*;
+import java.util.List;
+
+import com.esb.esbapp.model.Challenge;
 
 
 
@@ -20,6 +23,12 @@ public class User {
     private String communityId;
 
     private Integer totalPoints = 0;
+
+    @ManyToMany
+    @JoinTable(name = "user_challenges",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "challenge_id"))
+    private List<Challenge> joinedChallenges;
 
     public User() {
     }
@@ -70,5 +79,13 @@ public class User {
 
     public void setTotalPoints(Integer totalPoints) {
         this.totalPoints = totalPoints;
+    }
+
+    public List<Challenge> getJoinedChallenges() {
+        return joinedChallenges;
+    }
+
+    public void setJoinedChallenges(List<Challenge> joinedChallenges) {
+        this.joinedChallenges = joinedChallenges;
     }
 }


### PR DESCRIPTION
## Summary
- add `joinedChallenges` relation in `User`
- link `Task` back to `Challenge`

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688210ea1378832e8cff1976d3d682c5