### PR TITLE
Implement gamification core APIs

### DIFF
--- a/ESB-APP/src/main/java/com/esb/esbapp/controller/LeaderboardController.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/controller/LeaderboardController.java
@@ -1,9 +1,8 @@
 package com.esb.esbapp.controller;
 
-import com.esb.esbapp.model.LeaderboardEntry;
+import com.esb.esbapp.model.User;
 import com.esb.esbapp.service.LeaderboardService;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,18 +18,18 @@ public class LeaderboardController {
         this.leaderboardService = leaderboardService;
     }
 
-    @GetMapping("/daily/{communityId}")
-    public List<LeaderboardEntry> daily(@PathVariable String communityId) {
-        return leaderboardService.getDailyLeaderboard(communityId);
+    @GetMapping("/daily")
+    public List<User> daily() {
+        return leaderboardService.getDailyLeaderboard();
     }
 
-    @GetMapping("/weekly/{communityId}")
-    public List<LeaderboardEntry> weekly(@PathVariable String communityId) {
-        return leaderboardService.getWeeklyLeaderboard(communityId);
+    @GetMapping("/weekly")
+    public List<User> weekly() {
+        return leaderboardService.getWeeklyLeaderboard();
     }
 
-    @GetMapping("/overall/{communityId}")
-    public List<LeaderboardEntry> overall(@PathVariable String communityId) {
-        return leaderboardService.getOverallLeaderboard(communityId);
+    @GetMapping("/all")
+    public List<User> overall() {
+        return leaderboardService.getOverallLeaderboard();
     }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/controller/RewardController.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/controller/RewardController.java
@@ -16,13 +16,8 @@ public class RewardController {
         this.rewardService = rewardService;
     }
 
-    @GetMapping("/")
+    @GetMapping
     public List<RewardItem> getRewards() {
         return rewardService.getAllRewards();
-    }
-
-    @PostMapping("/redeem")
-    public void redeem(@RequestParam Long userId, @RequestParam Long rewardItemId) {
-        rewardService.redeem(userId, rewardItemId);
     }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/controller/TaskController.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/controller/TaskController.java
@@ -1,12 +1,9 @@
 package com.esb.esbapp.controller;
 
 import com.esb.esbapp.model.Task;
-import com.esb.esbapp.model.TaskRecord;
 import com.esb.esbapp.service.TaskService;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -19,22 +16,9 @@ public class TaskController {
         this.taskService = taskService;
     }
 
-    @GetMapping("/")
+    @GetMapping
     public List<Task> getTasks(@RequestParam(required = false) String category,
                                @RequestParam(required = false) Boolean enabled) {
         return taskService.getTasks(category, enabled);
-    }
-
-    @GetMapping("/completed/{userId}/{date}")
-    public List<TaskRecord> getCompleted(@PathVariable Long userId,
-                                         @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-        return taskService.getCompletedTasks(userId, date);
-    }
-
-    @PostMapping("/complete")
-    public void complete(@RequestParam Long userId,
-                         @RequestParam Long taskId,
-                         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-        taskService.completeTask(userId, taskId, date);
     }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/controller/UserController.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/controller/UserController.java
@@ -1,10 +1,52 @@
 package com.esb.esbapp.controller;
 
-import org.springframework.web.bind.annotation.RestController;
+import com.esb.esbapp.model.User;
+import com.esb.esbapp.repository.UserRepository;
+import com.esb.esbapp.service.RewardService;
+import com.esb.esbapp.service.TaskService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 /**
  * REST controller for user related endpoints.
  */
 @RestController
+@RequestMapping("/api/users")
 public class UserController {
+
+    private final UserRepository userRepository;
+    private final TaskService taskService;
+    private final RewardService rewardService;
+
+    public UserController(UserRepository userRepository, TaskService taskService, RewardService rewardService) {
+        this.userRepository = userRepository;
+        this.taskService = taskService;
+        this.rewardService = rewardService;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> getUser(@PathVariable Long id) {
+        Optional<User> user = userRepository.findById(id);
+        return user.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/{userId}/complete-task/{taskId}")
+    public ResponseEntity<User> completeTask(@PathVariable Long userId, @PathVariable Long taskId) {
+        User updated = taskService.completeTask(userId, taskId);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @PostMapping("/{userId}/redeem/{rewardItemId}")
+    public ResponseEntity<String> redeem(@PathVariable Long userId, @PathVariable Long rewardItemId) {
+        boolean ok = rewardService.redeem(userId, rewardItemId);
+        if (!ok) {
+            return ResponseEntity.badRequest().body("Not enough points.");
+        }
+        return ResponseEntity.ok("Success");
+    }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/model/RewardItem.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/model/RewardItem.java
@@ -18,16 +18,19 @@ public class RewardItem {
 
     private Integer costPoints;
 
+    private String imageUrl;
+
     private Integer stock;
 
     public RewardItem() {
     }
 
-    public RewardItem(Long id, String name, String description, Integer costPoints, Integer stock) {
+    public RewardItem(Long id, String name, String description, Integer costPoints, String imageUrl, Integer stock) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.costPoints = costPoints;
+        this.imageUrl = imageUrl;
         this.stock = stock;
     }
 
@@ -61,6 +64,14 @@ public class RewardItem {
 
     public void setCostPoints(Integer costPoints) {
         this.costPoints = costPoints;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 
     public Integer getStock() {

--- a/ESB-APP/src/main/java/com/esb/esbapp/model/Task.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/model/Task.java
@@ -18,7 +18,8 @@ public class Task {
 
     private String category;
 
-    private Integer points;
+    // rewardPoints specifies the points gained when completing the task
+    private Integer rewardPoints;
 
     private Boolean enabled = true;
 
@@ -29,12 +30,12 @@ public class Task {
     public Task() {
     }
 
-    public Task(Long id, String title, String description, String category, Integer points, Boolean enabled) {
+    public Task(Long id, String title, String description, String category, Integer rewardPoints, Boolean enabled) {
         this.id = id;
         this.title = title;
         this.description = description;
         this.category = category;
-        this.points = points;
+        this.rewardPoints = rewardPoints;
         this.enabled = enabled;
     }
 
@@ -70,12 +71,12 @@ public class Task {
         this.category = category;
     }
 
-    public Integer getPoints() {
-        return points;
+    public Integer getRewardPoints() {
+        return rewardPoints;
     }
 
-    public void setPoints(Integer points) {
-        this.points = points;
+    public void setRewardPoints(Integer rewardPoints) {
+        this.rewardPoints = rewardPoints;
     }
 
     public Boolean getEnabled() {

--- a/ESB-APP/src/main/java/com/esb/esbapp/model/User.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/model/User.java
@@ -15,14 +15,18 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
+    // Display name of the user
+    private String username;
 
-    @Column(unique = true)
-    private String email;
+    private String avatarUrl;
 
-    private String communityId;
+    private int dailyPoints;
+    private int weeklyPoints;
+    private int totalPoints;
 
-    private Integer totalPoints = 0;
+    private double dailyEnergy;
+    private double weeklyEnergy;
+    private double monthlyEnergy;
 
     @ManyToMany
     @JoinTable(name = "user_challenges",
@@ -33,11 +37,12 @@ public class User {
     public User() {
     }
 
-    public User(Long id, String name, String email, String communityId, Integer totalPoints) {
+    public User(Long id, String username, String avatarUrl, int dailyPoints, int weeklyPoints, int totalPoints) {
         this.id = id;
-        this.name = name;
-        this.email = email;
-        this.communityId = communityId;
+        this.username = username;
+        this.avatarUrl = avatarUrl;
+        this.dailyPoints = dailyPoints;
+        this.weeklyPoints = weeklyPoints;
         this.totalPoints = totalPoints;
     }
 
@@ -49,36 +54,68 @@ public class User {
         this.id = id;
     }
 
-    public String getName() {
-        return name;
+    public String getUsername() {
+        return username;
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public void setUsername(String username) {
+        this.username = username;
     }
 
-    public String getEmail() {
-        return email;
+    public String getAvatarUrl() {
+        return avatarUrl;
     }
 
-    public void setEmail(String email) {
-        this.email = email;
+    public void setAvatarUrl(String avatarUrl) {
+        this.avatarUrl = avatarUrl;
     }
 
-    public String getCommunityId() {
-        return communityId;
+    public int getDailyPoints() {
+        return dailyPoints;
     }
 
-    public void setCommunityId(String communityId) {
-        this.communityId = communityId;
+    public void setDailyPoints(int dailyPoints) {
+        this.dailyPoints = dailyPoints;
     }
 
-    public Integer getTotalPoints() {
+    public int getWeeklyPoints() {
+        return weeklyPoints;
+    }
+
+    public void setWeeklyPoints(int weeklyPoints) {
+        this.weeklyPoints = weeklyPoints;
+    }
+
+    public int getTotalPoints() {
         return totalPoints;
     }
 
-    public void setTotalPoints(Integer totalPoints) {
+    public void setTotalPoints(int totalPoints) {
         this.totalPoints = totalPoints;
+    }
+
+    public double getDailyEnergy() {
+        return dailyEnergy;
+    }
+
+    public void setDailyEnergy(double dailyEnergy) {
+        this.dailyEnergy = dailyEnergy;
+    }
+
+    public double getWeeklyEnergy() {
+        return weeklyEnergy;
+    }
+
+    public void setWeeklyEnergy(double weeklyEnergy) {
+        this.weeklyEnergy = weeklyEnergy;
+    }
+
+    public double getMonthlyEnergy() {
+        return monthlyEnergy;
+    }
+
+    public void setMonthlyEnergy(double monthlyEnergy) {
+        this.monthlyEnergy = monthlyEnergy;
     }
 
     public List<Challenge> getJoinedChallenges() {

--- a/ESB-APP/src/main/java/com/esb/esbapp/repository/UserRepository.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/repository/UserRepository.java
@@ -9,7 +9,9 @@ import java.util.List;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    List<User> findByCommunityId(String communityId);
+    List<User> findTop10ByOrderByDailyPointsDesc();
 
-    List<User> findTop10ByCommunityIdOrderByTotalPointsDesc(String communityId);
+    List<User> findTop10ByOrderByWeeklyPointsDesc();
+
+    List<User> findTop10ByOrderByTotalPointsDesc();
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/service/LeaderboardService.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/service/LeaderboardService.java
@@ -1,11 +1,11 @@
 package com.esb.esbapp.service;
 
-import com.esb.esbapp.model.LeaderboardEntry;
+import com.esb.esbapp.model.User;
 
 import java.util.List;
 
 public interface LeaderboardService {
-    List<LeaderboardEntry> getDailyLeaderboard(String communityId);
-    List<LeaderboardEntry> getWeeklyLeaderboard(String communityId);
-    List<LeaderboardEntry> getOverallLeaderboard(String communityId);
+    List<User> getDailyLeaderboard();
+    List<User> getWeeklyLeaderboard();
+    List<User> getOverallLeaderboard();
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/service/RewardService.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/service/RewardService.java
@@ -6,5 +6,11 @@ import java.util.List;
 
 public interface RewardService {
     List<RewardItem> getAllRewards();
-    void redeem(Long userId, Long rewardItemId);
+
+    /**
+     * Attempt to redeem the specified reward item for a user.
+     *
+     * @return true if redemption succeeded
+     */
+    boolean redeem(Long userId, Long rewardItemId);
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/service/TaskService.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/service/TaskService.java
@@ -1,15 +1,18 @@
 package com.esb.esbapp.service;
 
 import com.esb.esbapp.model.Task;
-import com.esb.esbapp.model.TaskRecord;
-
-import java.time.LocalDate;
 import java.util.List;
+import com.esb.esbapp.model.User;
 
 public interface TaskService {
     List<Task> getTasks(String category, Boolean enabled);
 
-    List<TaskRecord> getCompletedTasks(Long userId, LocalDate date);
-
-    void completeTask(Long userId, Long taskId, LocalDate date);
+    /**
+     * Mark a task as completed and update the user's points accordingly.
+     *
+     * @param userId id of the user
+     * @param taskId id of the task
+     * @return updated user or {@code null} if user/task not found
+     */
+    User completeTask(Long userId, Long taskId);
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/service/impl/LeaderboardServiceImpl.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/service/impl/LeaderboardServiceImpl.java
@@ -1,78 +1,33 @@
 package com.esb.esbapp.service.impl;
 
-import com.esb.esbapp.model.LeaderboardEntry;
-import com.esb.esbapp.model.TaskRecord;
 import com.esb.esbapp.model.User;
-import com.esb.esbapp.repository.TaskRecordRepository;
 import com.esb.esbapp.repository.UserRepository;
 import com.esb.esbapp.service.LeaderboardService;
 import org.springframework.stereotype.Service;
 
-import java.time.DayOfWeek;
-import java.time.LocalDate;
-import java.time.temporal.TemporalAdjusters;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.List;
 
 @Service
 public class LeaderboardServiceImpl implements LeaderboardService {
 
     private final UserRepository userRepository;
-    private final TaskRecordRepository taskRecordRepository;
 
-    public LeaderboardServiceImpl(UserRepository userRepository, TaskRecordRepository taskRecordRepository) {
+    public LeaderboardServiceImpl(UserRepository userRepository) {
         this.userRepository = userRepository;
-        this.taskRecordRepository = taskRecordRepository;
     }
 
     @Override
-    public List<LeaderboardEntry> getDailyLeaderboard(String communityId) {
-        LocalDate today = LocalDate.now();
-        return buildLeaderboard(communityId, today, today);
+    public List<User> getDailyLeaderboard() {
+        return userRepository.findTop10ByOrderByDailyPointsDesc();
     }
 
     @Override
-    public List<LeaderboardEntry> getWeeklyLeaderboard(String communityId) {
-        LocalDate now = LocalDate.now();
-        LocalDate start = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-        return buildLeaderboard(communityId, start, now);
+    public List<User> getWeeklyLeaderboard() {
+        return userRepository.findTop10ByOrderByWeeklyPointsDesc();
     }
 
     @Override
-    public List<LeaderboardEntry> getOverallLeaderboard(String communityId) {
-        List<User> users = userRepository.findTop10ByCommunityIdOrderByTotalPointsDesc(communityId);
-        return users.stream()
-                .map(u -> {
-                    LeaderboardEntry e = new LeaderboardEntry();
-                    e.setUserName(u.getName());
-                    e.setScore(u.getTotalPoints());
-                    e.setCommunityId(u.getCommunityId());
-                    return e;
-                })
-                .collect(Collectors.toList());
-    }
-
-    private List<LeaderboardEntry> buildLeaderboard(String communityId, LocalDate start, LocalDate end) {
-        List<User> users = userRepository.findByCommunityId(communityId);
-        Map<Long, Integer> scores = new HashMap<>();
-        for (User user : users) {
-            List<TaskRecord> records = taskRecordRepository.findByUserIdAndCompletedDateBetween(user.getId(), start, end);
-            int total = records.stream().mapToInt(TaskRecord::getEarnedPoints).sum();
-            if (total > 0) {
-                scores.put(user.getId(), total);
-            }
-        }
-        return scores.entrySet().stream()
-                .sorted(Map.Entry.<Long, Integer>comparingByValue().reversed())
-                .limit(10)
-                .map(entry -> {
-                    User u = userRepository.findById(entry.getKey()).orElseThrow();
-                    LeaderboardEntry dto = new LeaderboardEntry();
-                    dto.setUserName(u.getName());
-                    dto.setScore(entry.getValue());
-                    dto.setCommunityId(u.getCommunityId());
-                    return dto;
-                })
-                .collect(Collectors.toList());
+    public List<User> getOverallLeaderboard() {
+        return userRepository.findTop10ByOrderByTotalPointsDesc();
     }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/service/impl/RewardServiceImpl.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/service/impl/RewardServiceImpl.java
@@ -28,15 +28,21 @@ public class RewardServiceImpl implements RewardService {
 
     @Override
     @Transactional
-    public void redeem(Long userId, Long rewardItemId) {
+    public boolean redeem(Long userId, Long rewardItemId) {
         RewardItem item = rewardItemRepository.findById(rewardItemId).orElse(null);
         User user = userRepository.findById(userId).orElse(null);
-        if (item == null || user == null || item.getStock() <= 0 || user.getTotalPoints() < item.getCostPoints()) {
-            return;
+        if (item == null || user == null || user.getTotalPoints() < item.getCostPoints()) {
+            return false;
         }
-        item.setStock(item.getStock() - 1);
+        if (item.getStock() != null && item.getStock() <= 0) {
+            return false;
+        }
+        if (item.getStock() != null) {
+            item.setStock(item.getStock() - 1);
+            rewardItemRepository.save(item);
+        }
         user.setTotalPoints(user.getTotalPoints() - item.getCostPoints());
-        rewardItemRepository.save(item);
         userRepository.save(user);
+        return true;
     }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/service/impl/TaskServiceImpl.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/service/impl/TaskServiceImpl.java
@@ -39,27 +39,25 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
-    public List<TaskRecord> getCompletedTasks(Long userId, LocalDate date) {
-        return taskRecordRepository.findByUserIdAndCompletedDate(userId, date);
-    }
-
-    @Override
     @Transactional
-    public void completeTask(Long userId, Long taskId, LocalDate date) {
+    public User completeTask(Long userId, Long taskId) {
         Optional<Task> taskOpt = taskRepository.findById(taskId);
         Optional<User> userOpt = userRepository.findById(userId);
         if (taskOpt.isEmpty() || userOpt.isEmpty()) {
-            return;
+            return null;
         }
         Task task = taskOpt.get();
         User user = userOpt.get();
         TaskRecord record = new TaskRecord();
         record.setUserId(userId);
         record.setTaskId(taskId);
-        record.setCompletedDate(date);
-        record.setEarnedPoints(task.getPoints());
+        record.setCompletedDate(LocalDate.now());
+        record.setEarnedPoints(task.getRewardPoints());
         taskRecordRepository.save(record);
-        user.setTotalPoints(user.getTotalPoints() + task.getPoints());
+        user.setDailyPoints(user.getDailyPoints() + task.getRewardPoints());
+        user.setWeeklyPoints(user.getWeeklyPoints() + task.getRewardPoints());
+        user.setTotalPoints(user.getTotalPoints() + task.getRewardPoints());
         userRepository.save(user);
+        return user;
     }
 }


### PR DESCRIPTION
## Summary
- add user rewards & redeem endpoints
- update task completion logic
- expand data models for users, tasks and rewards
- expose simple leaderboard endpoints

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6882553734f8832e86f2d5c33b7f422d