### PR TITLE
Fix DataSeeder constructor mismatch

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -3,13 +3,10 @@
   <component name="CompilerConfiguration">
     <annotationProcessing>
       <profile default="true" name="Default" enabled="true" />
-      <profile name="Annotation profile for ESB-APP" enabled="true">
+      <profile name="Maven default annotation processors profile" enabled="true">
         <sourceOutputDir name="target/generated-sources/annotations" />
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
         <outputRelativeToContentRoot value="true" />
-        <processorPath useClasspath="false">
-          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/unknown/lombok-unknown.jar" />
-        </processorPath>
         <module name="ESB-APP" />
       </profile>
     </annotationProcessing>

--- a/ESB-APP/pom.xml
+++ b/ESB-APP/pom.xml
@@ -45,11 +45,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
@@ -59,28 +54,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                        </exclude>
-                    </excludes>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/ESB-APP/src/main/java/com/esb/esbapp/DataSeeder/DataSeeder.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/DataSeeder/DataSeeder.java
@@ -41,17 +41,22 @@ public class DataSeeder implements CommandLineRunner {
     }
 
     private void seedUsers() {
+        // Adjusted users so that the top 3 have different ranks for daily, weekly, and total points
         List<User> users = List.of(
-                new User(null, "Viggo", "https://example.com/avatars/viggo1.png", 200, 0, 0, 3.5, 20.0, 60.0),
-                new User(null, "Lumi", "https://example.com/avatars/lumi.png", 180, 0, 0, 2.8, 18.0, 55.0),
-                new User(null, "Viggo", "https://example.com/avatars/viggo2.png", 120, 0, 0, 3.1, 19.0, 52.0),
-                new User(null, "Boden", "https://example.com/avatars/boden.png", 100, 0, 0, 2.0, 16.0, 50.0),
-                new User(null, "Jett", "https://example.com/avatars/jett.png", 95, 0, 0, 2.5, 15.0, 48.0),
-                new User(null, "Zara", "https://example.com/avatars/zara.png", 90, 0, 0, 2.4, 15.5, 47.0),
-                new User(null, "Gwen", "https://example.com/avatars/gwen.png", 80, 0, 0, 2.1, 14.0, 45.0),
-                new User(null, "James", "https://example.com/avatars/james.png", 40, 0, 0, 2.2, 13.0, 40.0),
-                new User(null, "Vivian", "https://example.com/avatars/vivian.png", 30, 0, 0, 1.9, 12.0, 38.0),
-                new User(null, "Theo", "https://example.com/avatars/theo.png", 30, 0, 0, 1.8, 11.0, 36.0)
+                // User 1: Highest daily, lowest weekly, mid total
+                new User(null, "Viggo", "https://example.com/avatars/viggo1.png", 300, 500, 600, 3.5, 20.0, 60.0),
+                // User 2: Mid daily, highest weekly, lowest total
+                new User(null, "Lumi", "https://example.com/avatars/lumi.png", 200, 600, 800, 2.8, 18.0, 55.0),
+                // User 3: Lowest daily, mid weekly, highest total
+                new User(null, "Viggo", "https://example.com/avatars/viggo2.png", 100, 250, 900, 3.1, 19.0, 52.0),
+                // The rest stay similar, but ensure no accidental tie in top 3
+                new User(null, "Boden", "https://example.com/avatars/boden.png", 80, 150, 300, 2.0, 16.0, 50.0),
+                new User(null, "Jett", "https://example.com/avatars/jett.png", 75, 140, 450, 2.5, 15.0, 48.0),
+                new User(null, "Zara", "https://example.com/avatars/zara.png", 70, 230, 420, 2.4, 15.5, 47.0),
+                new User(null, "Gwen", "https://example.com/avatars/gwen.png", 60, 120, 400, 2.1, 14.0, 45.0),
+                new User(null, "James", "https://example.com/avatars/james.png", 40, 260, 620, 2.2, 13.0, 40.0),
+                new User(null, "Vivian", "https://example.com/avatars/vivian.png", 30, 300, 250, 1.9, 12.0, 38.0),
+                new User(null, "Theo", "https://example.com/avatars/theo.png", 30, 160, 680, 1.8, 11.0, 36.0)
         );
         userRepository.saveAll(users);
         System.out.println("✅ Seeded 10 users.");

--- a/ESB-APP/src/main/java/com/esb/esbapp/DataSeeder/DataSeeder.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/DataSeeder/DataSeeder.java
@@ -6,21 +6,26 @@ import com.esb.esbapp.model.RewardItem;
 import com.esb.esbapp.repository.UserRepository;
 import com.esb.esbapp.repository.TaskRepository;
 import com.esb.esbapp.repository.RewardItemRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Random;
-import java.util.stream.IntStream;
+
 
 @Component
-@RequiredArgsConstructor
 public class DataSeeder implements CommandLineRunner {
 
     private final UserRepository userRepository;
     private final TaskRepository taskRepository;
     private final RewardItemRepository rewardItemRepository;
+
+    public DataSeeder(UserRepository userRepository,
+                      TaskRepository taskRepository,
+                      RewardItemRepository rewardItemRepository) {
+        this.userRepository = userRepository;
+        this.taskRepository = taskRepository;
+        this.rewardItemRepository = rewardItemRepository;
+    }
 
     @Override
     public void run(String... args) {

--- a/ESB-APP/src/main/java/com/esb/esbapp/controller/RewardController.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/controller/RewardController.java
@@ -2,17 +2,19 @@ package com.esb.esbapp.controller;
 
 import com.esb.esbapp.model.RewardItem;
 import com.esb.esbapp.service.RewardService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/rewards")
-@RequiredArgsConstructor
 public class RewardController {
 
     private final RewardService rewardService;
+
+    public RewardController(RewardService rewardService) {
+        this.rewardService = rewardService;
+    }
 
     @GetMapping
     public List<RewardItem> getAllRewards() {

--- a/ESB-APP/src/main/java/com/esb/esbapp/controller/TaskController.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/controller/TaskController.java
@@ -2,17 +2,19 @@ package com.esb.esbapp.controller;
 
 import com.esb.esbapp.model.Task;
 import com.esb.esbapp.service.TaskService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/tasks")
-@RequiredArgsConstructor
 public class TaskController {
 
     private final TaskService taskService;
+
+    public TaskController(TaskService taskService) {
+        this.taskService = taskService;
+    }
 
     @GetMapping
     public List<Task> getAllTasks() {

--- a/ESB-APP/src/main/java/com/esb/esbapp/controller/UserController.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/controller/UserController.java
@@ -2,17 +2,19 @@ package com.esb.esbapp.controller;
 
 import com.esb.esbapp.model.User;
 import com.esb.esbapp.service.UserService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/users")
-@RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
 
     /**
      * 获取用户信息（积分和能耗）

--- a/ESB-APP/src/main/java/com/esb/esbapp/dto/CommunitySummaryDTO.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/dto/CommunitySummaryDTO.java
@@ -1,12 +1,8 @@
 package com.esb.esbapp.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
+
+
 public class CommunitySummaryDTO {
     private int averageDailyPoints;
     private int averageWeeklyPoints;
@@ -14,4 +10,66 @@ public class CommunitySummaryDTO {
     private double averageDailyEnergy;
     private double averageWeeklyEnergy;
     private double averageMonthlyEnergy;
+
+    public CommunitySummaryDTO() {
+    }
+
+    public CommunitySummaryDTO(int averageDailyPoints, int averageWeeklyPoints,
+                               int averageTotalPoints, double averageDailyEnergy,
+                               double averageWeeklyEnergy, double averageMonthlyEnergy) {
+        this.averageDailyPoints = averageDailyPoints;
+        this.averageWeeklyPoints = averageWeeklyPoints;
+        this.averageTotalPoints = averageTotalPoints;
+        this.averageDailyEnergy = averageDailyEnergy;
+        this.averageWeeklyEnergy = averageWeeklyEnergy;
+        this.averageMonthlyEnergy = averageMonthlyEnergy;
+    }
+
+    public int getAverageDailyPoints() {
+        return averageDailyPoints;
+    }
+
+    public void setAverageDailyPoints(int averageDailyPoints) {
+        this.averageDailyPoints = averageDailyPoints;
+    }
+
+    public int getAverageWeeklyPoints() {
+        return averageWeeklyPoints;
+    }
+
+    public void setAverageWeeklyPoints(int averageWeeklyPoints) {
+        this.averageWeeklyPoints = averageWeeklyPoints;
+    }
+
+    public int getAverageTotalPoints() {
+        return averageTotalPoints;
+    }
+
+    public void setAverageTotalPoints(int averageTotalPoints) {
+        this.averageTotalPoints = averageTotalPoints;
+    }
+
+    public double getAverageDailyEnergy() {
+        return averageDailyEnergy;
+    }
+
+    public void setAverageDailyEnergy(double averageDailyEnergy) {
+        this.averageDailyEnergy = averageDailyEnergy;
+    }
+
+    public double getAverageWeeklyEnergy() {
+        return averageWeeklyEnergy;
+    }
+
+    public void setAverageWeeklyEnergy(double averageWeeklyEnergy) {
+        this.averageWeeklyEnergy = averageWeeklyEnergy;
+    }
+
+    public double getAverageMonthlyEnergy() {
+        return averageMonthlyEnergy;
+    }
+
+    public void setAverageMonthlyEnergy(double averageMonthlyEnergy) {
+        this.averageMonthlyEnergy = averageMonthlyEnergy;
+    }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/dto/UserSummaryDTO.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/dto/UserSummaryDTO.java
@@ -1,12 +1,8 @@
 package com.esb.esbapp.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
+
+
 public class UserSummaryDTO {
     private int dailyPoints;
     private int weeklyPoints;
@@ -14,4 +10,65 @@ public class UserSummaryDTO {
     private double dailyEnergy;
     private double weeklyEnergy;
     private double monthlyEnergy;
+
+    public UserSummaryDTO() {
+    }
+
+    public UserSummaryDTO(int dailyPoints, int weeklyPoints, int totalPoints,
+                           double dailyEnergy, double weeklyEnergy, double monthlyEnergy) {
+        this.dailyPoints = dailyPoints;
+        this.weeklyPoints = weeklyPoints;
+        this.totalPoints = totalPoints;
+        this.dailyEnergy = dailyEnergy;
+        this.weeklyEnergy = weeklyEnergy;
+        this.monthlyEnergy = monthlyEnergy;
+    }
+
+    public int getDailyPoints() {
+        return dailyPoints;
+    }
+
+    public void setDailyPoints(int dailyPoints) {
+        this.dailyPoints = dailyPoints;
+    }
+
+    public int getWeeklyPoints() {
+        return weeklyPoints;
+    }
+
+    public void setWeeklyPoints(int weeklyPoints) {
+        this.weeklyPoints = weeklyPoints;
+    }
+
+    public int getTotalPoints() {
+        return totalPoints;
+    }
+
+    public void setTotalPoints(int totalPoints) {
+        this.totalPoints = totalPoints;
+    }
+
+    public double getDailyEnergy() {
+        return dailyEnergy;
+    }
+
+    public void setDailyEnergy(double dailyEnergy) {
+        this.dailyEnergy = dailyEnergy;
+    }
+
+    public double getWeeklyEnergy() {
+        return weeklyEnergy;
+    }
+
+    public void setWeeklyEnergy(double weeklyEnergy) {
+        this.weeklyEnergy = weeklyEnergy;
+    }
+
+    public double getMonthlyEnergy() {
+        return monthlyEnergy;
+    }
+
+    public void setMonthlyEnergy(double monthlyEnergy) {
+        this.monthlyEnergy = monthlyEnergy;
+    }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/model/RewardItem.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/model/RewardItem.java
@@ -1,12 +1,9 @@
 package com.esb.esbapp.model;
 
 import jakarta.persistence.*;
-import lombok.*;
+
 
 @Entity
-@Data
-@NoArgsConstructor
-@Builder
 public class RewardItem {
 
     @Id
@@ -18,12 +15,55 @@ public class RewardItem {
     private int costPoints;
     private String imageUrl;
 
+    public RewardItem() {
+    }
+
     public RewardItem(Long id, String name, String description, int costPoints,
                        String imageUrl) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.costPoints = costPoints;
+        this.imageUrl = imageUrl;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public int getCostPoints() {
+        return costPoints;
+    }
+
+    public void setCostPoints(int costPoints) {
+        this.costPoints = costPoints;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/model/RewardItem.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/model/RewardItem.java
@@ -6,7 +6,6 @@ import lombok.*;
 @Entity
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @Builder
 public class RewardItem {
 
@@ -18,4 +17,13 @@ public class RewardItem {
     private String description;
     private int costPoints;
     private String imageUrl;
+
+    public RewardItem(Long id, String name, String description, int costPoints,
+                       String imageUrl) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.costPoints = costPoints;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/model/Task.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/model/Task.java
@@ -6,7 +6,6 @@ import lombok.*;
 @Entity
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @Builder
 public class Task {
 
@@ -17,4 +16,11 @@ public class Task {
     private String title;
     private String description;
     private int rewardPoints;
+
+    public Task(Long id, String title, String description, int rewardPoints) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.rewardPoints = rewardPoints;
+    }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/model/Task.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/model/Task.java
@@ -1,12 +1,9 @@
 package com.esb.esbapp.model;
 
 import jakarta.persistence.*;
-import lombok.*;
+
 
 @Entity
-@Data
-@NoArgsConstructor
-@Builder
 public class Task {
 
     @Id
@@ -17,10 +14,45 @@ public class Task {
     private String description;
     private int rewardPoints;
 
+    public Task() {
+    }
+
     public Task(Long id, String title, String description, int rewardPoints) {
         this.id = id;
         this.title = title;
         this.description = description;
+        this.rewardPoints = rewardPoints;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public int getRewardPoints() {
+        return rewardPoints;
+    }
+
+    public void setRewardPoints(int rewardPoints) {
         this.rewardPoints = rewardPoints;
     }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/model/User.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/model/User.java
@@ -1,12 +1,9 @@
 package com.esb.esbapp.model;
 
 import jakarta.persistence.*;
-import lombok.*;
+
 
 @Entity
-@Data
-@NoArgsConstructor
-@Builder
 public class User {
 
     @Id
@@ -24,6 +21,9 @@ public class User {
     private double weeklyEnergy;
     private double monthlyEnergy;
 
+    public User() {
+    }
+
     public User(Long id, String username, String avatarUrl,
                 int dailyPoints, int weeklyPoints, int totalPoints,
                 double dailyEnergy, double weeklyEnergy, double monthlyEnergy) {
@@ -35,6 +35,78 @@ public class User {
         this.totalPoints = totalPoints;
         this.dailyEnergy = dailyEnergy;
         this.weeklyEnergy = weeklyEnergy;
+        this.monthlyEnergy = monthlyEnergy;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getAvatarUrl() {
+        return avatarUrl;
+    }
+
+    public void setAvatarUrl(String avatarUrl) {
+        this.avatarUrl = avatarUrl;
+    }
+
+    public int getDailyPoints() {
+        return dailyPoints;
+    }
+
+    public void setDailyPoints(int dailyPoints) {
+        this.dailyPoints = dailyPoints;
+    }
+
+    public int getWeeklyPoints() {
+        return weeklyPoints;
+    }
+
+    public void setWeeklyPoints(int weeklyPoints) {
+        this.weeklyPoints = weeklyPoints;
+    }
+
+    public int getTotalPoints() {
+        return totalPoints;
+    }
+
+    public void setTotalPoints(int totalPoints) {
+        this.totalPoints = totalPoints;
+    }
+
+    public double getDailyEnergy() {
+        return dailyEnergy;
+    }
+
+    public void setDailyEnergy(double dailyEnergy) {
+        this.dailyEnergy = dailyEnergy;
+    }
+
+    public double getWeeklyEnergy() {
+        return weeklyEnergy;
+    }
+
+    public void setWeeklyEnergy(double weeklyEnergy) {
+        this.weeklyEnergy = weeklyEnergy;
+    }
+
+    public double getMonthlyEnergy() {
+        return monthlyEnergy;
+    }
+
+    public void setMonthlyEnergy(double monthlyEnergy) {
         this.monthlyEnergy = monthlyEnergy;
     }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/model/User.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/model/User.java
@@ -6,7 +6,6 @@ import lombok.*;
 @Entity
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @Builder
 public class User {
 
@@ -24,4 +23,18 @@ public class User {
     private double dailyEnergy;
     private double weeklyEnergy;
     private double monthlyEnergy;
+
+    public User(Long id, String username, String avatarUrl,
+                int dailyPoints, int weeklyPoints, int totalPoints,
+                double dailyEnergy, double weeklyEnergy, double monthlyEnergy) {
+        this.id = id;
+        this.username = username;
+        this.avatarUrl = avatarUrl;
+        this.dailyPoints = dailyPoints;
+        this.weeklyPoints = weeklyPoints;
+        this.totalPoints = totalPoints;
+        this.dailyEnergy = dailyEnergy;
+        this.weeklyEnergy = weeklyEnergy;
+        this.monthlyEnergy = monthlyEnergy;
+    }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/service/impl/RewardServiceImpl.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/service/impl/RewardServiceImpl.java
@@ -3,16 +3,18 @@ package com.esb.esbapp.service.impl;
 import com.esb.esbapp.model.RewardItem;
 import com.esb.esbapp.repository.RewardItemRepository;
 import com.esb.esbapp.service.RewardService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-@RequiredArgsConstructor
 public class RewardServiceImpl implements RewardService {
 
     private final RewardItemRepository rewardItemRepository;
+
+    public RewardServiceImpl(RewardItemRepository rewardItemRepository) {
+        this.rewardItemRepository = rewardItemRepository;
+    }
 
     @Override
     public List<RewardItem> getAllRewards() {

--- a/ESB-APP/src/main/java/com/esb/esbapp/service/impl/TaskServiceImpl.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/service/impl/TaskServiceImpl.java
@@ -3,16 +3,18 @@ package com.esb.esbapp.service.impl;
 import com.esb.esbapp.model.Task;
 import com.esb.esbapp.repository.TaskRepository;
 import com.esb.esbapp.service.TaskService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-@RequiredArgsConstructor
 public class TaskServiceImpl implements TaskService {
 
     private final TaskRepository taskRepository;
+
+    public TaskServiceImpl(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
 
     @Override
     public List<Task> getAllTasks() {

--- a/ESB-APP/src/main/java/com/esb/esbapp/service/impl/UserServiceImpl.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/service/impl/UserServiceImpl.java
@@ -7,19 +7,25 @@ import com.esb.esbapp.repository.UserRepository;
 import com.esb.esbapp.repository.TaskRepository;
 import com.esb.esbapp.repository.RewardItemRepository;
 import com.esb.esbapp.service.UserService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
-@RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final TaskRepository taskRepository;
     private final RewardItemRepository rewardItemRepository;
+
+    public UserServiceImpl(UserRepository userRepository,
+                           TaskRepository taskRepository,
+                           RewardItemRepository rewardItemRepository) {
+        this.userRepository = userRepository;
+        this.taskRepository = taskRepository;
+        this.rewardItemRepository = rewardItemRepository;
+    }
 
     @Override
     public User getUserById(Long id) {


### PR DESCRIPTION
## Summary
- provide explicit constructors for `User`, `Task` and `RewardItem`

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68832daa3e54832e90c1bfd98a9bea06