### PR TITLE
Connect frontend with backend API

### DIFF
--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -22,30 +22,46 @@ import { Images } from '../assets';
 export default function HomeScreen() {
   const [mode, setMode] = useState('home');    // 'home' 或 'community'
   const [stats, setStats] = useState(null);
+  const [angles, setAngles] = useState({
+    frontStart: 0,
+    frontEnd: 180,
+    backStart: 180,
+    backEnd: 360,
+  });
   const animated = useRef(new Animated.Value(0)).current;
 
   // 当 mode 改变时拉取数据
   useEffect(() => {
     setStats(null);
     fetchEnergyStats(mode)
-      .then(data => setStats(data))
+      .then(data => {
+        setStats(data);
+        if (data && data.frontEnd !== undefined) {
+          setAngles({
+            frontStart: data.frontStart ?? 0,
+            frontEnd: data.frontEnd ?? 180,
+            backStart: data.backStart ?? 180,
+            backEnd: data.backEnd ?? 360,
+          });
+        }
+      })
       .catch(err => console.error(err));
   }, [mode]);
 
   // 翻转动画插值
   const frontInterpol = animated.interpolate({
-    inputRange: [0, 180],
-    outputRange: ['0deg', '180deg'],
+    inputRange: [0, angles.frontEnd],
+    outputRange: [`${angles.frontStart}deg`, `${angles.frontEnd}deg`],
   });
   const backInterpol = animated.interpolate({
-    inputRange: [0, 180],
-    outputRange: ['180deg', '360deg'],
+    inputRange: [0, angles.backEnd],
+    outputRange: [`${angles.backStart}deg`, `${angles.backEnd}deg`],
   });
 
   // 执行动画并切换模式
   const flipCard = () => {
     Animated.spring(animated, {
-      toValue: mode === 'home' ? 180 : 0,
+      toValue: mode === 'home' ? angles.frontEnd : 0,
       friction: 8,
       tension: 10,
       useNativeDriver: true,

--- a/services/api.js
+++ b/services/api.js
@@ -1,24 +1,23 @@
 // services/api.js
 
+const API_BASE_URL = process.env.API_URL || 'http://localhost:3000';
+
 /**
- * 模拟获取能耗统计（快速预览用）
- * @param {'home'|'community'} mode 
+ * 获取能耗统计数据
+ * @param {'home'|'community'} mode
  */
 export async function fetchEnergyStats(mode) {
-  // 这里返回假数据，接真实接口时改成 fetch 调用即可
-  return {
-    used: 123.4,
-    earned: 56,
-    weekly: [
-      { day: 'M', used: 10, earned: 30 },
-      { day: 'T', used: 12, earned: 25 },
-      { day: 'W', used:  8, earned: 20 },
-      { day: 'T', used: 15, earned: 40 },
-      { day: 'F', used: 20, earned: 50 },
-      { day: 'S', used: 18, earned: 45 },
-      { day: 'S', used: 22, earned: 55 },
-    ],
-  };
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/users/stats?mode=${mode}`);
+    if (!res.ok) {
+      throw new Error(`Request failed: ${res.status}`);
+    }
+    const data = await res.json();
+    return data;
+  } catch (err) {
+    console.error('fetchEnergyStats error', err);
+    throw err;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- fetch energy stats from backend instead of mock data
- allow backend-provided rotation ranges
- use backend angles when animating cards

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6886099b4120832eb458ccfd67cc01a4