### PR TITLE
Switch frontend mock data to backend APIs

### DIFF
--- a/ESB-APP/src/main/java/com/esb/esbapp/DataSeeder/DataSeeder.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/DataSeeder/DataSeeder.java
@@ -44,19 +44,19 @@ public class DataSeeder implements CommandLineRunner {
         // Adjusted users so that the top 3 have different ranks for daily, weekly, and total points
         List<User> users = List.of(
                 // User 1: Highest daily, lowest weekly, mid total
-                new User(null, "Viggo", "https://example.com/avatars/viggo1.png", 300, 500, 600, 3.5, 20.0, 60.0),
+                new User(null, "Viggo", 300, 500, 600, 3.5, 20.0, 60.0),
                 // User 2: Mid daily, highest weekly, lowest total
-                new User(null, "Lumi", "https://example.com/avatars/lumi.png", 200, 600, 800, 2.8, 18.0, 55.0),
+                new User(null, "Lumi", 200, 600, 800, 2.8, 18.0, 55.0),
                 // User 3: Lowest daily, mid weekly, highest total
-                new User(null, "Viggo", "https://example.com/avatars/viggo2.png", 100, 250, 900, 3.1, 19.0, 52.0),
+                new User(null, "Viggo", 100, 250, 900, 3.1, 19.0, 52.0),
                 // The rest stay similar, but ensure no accidental tie in top 3
-                new User(null, "Boden", "https://example.com/avatars/boden.png", 80, 150, 300, 2.0, 16.0, 50.0),
-                new User(null, "Jett", "https://example.com/avatars/jett.png", 75, 140, 450, 2.5, 15.0, 48.0),
-                new User(null, "Zara", "https://example.com/avatars/zara.png", 70, 230, 420, 2.4, 15.5, 47.0),
-                new User(null, "Gwen", "https://example.com/avatars/gwen.png", 60, 120, 400, 2.1, 14.0, 45.0),
-                new User(null, "James", "https://example.com/avatars/james.png", 40, 260, 620, 2.2, 13.0, 40.0),
-                new User(null, "Vivian", "https://example.com/avatars/vivian.png", 30, 300, 250, 1.9, 12.0, 38.0),
-                new User(null, "Theo", "https://example.com/avatars/theo.png", 30, 160, 680, 1.8, 11.0, 36.0)
+                new User(null, "Boden", 80, 150, 300, 2.0, 16.0, 50.0),
+                new User(null, "Jett", 75, 140, 450, 2.5, 15.0, 48.0),
+                new User(null, "Zara", 70, 230, 420, 2.4, 15.5, 47.0),
+                new User(null, "Gwen", 60, 120, 400, 2.1, 14.0, 45.0),
+                new User(null, "James", 40, 260, 620, 2.2, 13.0, 40.0),
+                new User(null, "Vivian", 30, 300, 250, 1.9, 12.0, 38.0),
+                new User(null, "Theo", 30, 160, 680, 1.8, 11.0, 36.0)
         );
         userRepository.saveAll(users);
         System.out.println("✅ Seeded 10 users.");
@@ -77,12 +77,12 @@ public class DataSeeder implements CommandLineRunner {
 
     private void seedRewards() {
         List<RewardItem> rewards = List.of(
-                new RewardItem(null, "Electricity Deduction Voucher €5", "€5 off your next electricity bill", 450, "https://example.com/images/electricity-5.png"),
-                new RewardItem(null, "Smart Meter", "Track your energy usage", 1200, "https://example.com/images/smart-meter.png"),
-                new RewardItem(null, "Supermarket Voucher €5", "Valid in major stores", 500, "https://example.com/images/supermarket.png"),
-                new RewardItem(null, "Electricity Deduction Voucher €1", "€1 off electricity bill", 100, "https://example.com/images/electricity-1.png"),
-                new RewardItem(null, "Mini Plant Planting Set", "Grow your own herbs or flowers", 400, "https://example.com/images/plant.png"),
-                new RewardItem(null, "Community Sharing Tool Voucher", "Borrow tools from community center", 300, "https://example.com/images/tools.png")
+                new RewardItem(null, "Electricity Deduction Voucher €5", "€5 off your next electricity bill", 450),
+                new RewardItem(null, "Smart Meter", "Track your energy usage", 1200),
+                new RewardItem(null, "Supermarket Voucher €5", "Valid in major stores", 500),
+                new RewardItem(null, "Electricity Deduction Voucher €1", "€1 off electricity bill", 100),
+                new RewardItem(null, "Mini Plant Planting Set", "Grow your own herbs or flowers", 400),
+                new RewardItem(null, "Community Sharing Tool Voucher", "Borrow tools from community center", 300)
         );
         rewardItemRepository.saveAll(rewards);
         System.out.println("✅ Seeded 6 reward items.");

--- a/ESB-APP/src/main/java/com/esb/esbapp/controller/UserController.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.esb.esbapp.controller;
 
+import com.esb.esbapp.dto.CommunitySummaryDTO;
+import com.esb.esbapp.dto.UserSummaryDTO;
 import com.esb.esbapp.model.User;
 import com.esb.esbapp.service.UserService;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +24,11 @@ public class UserController {
     @GetMapping("/{id}")
     public User getUserById(@PathVariable Long id) {
         return userService.getUserById(id);
+    }
+
+    @GetMapping("/{id}/summary")
+    public UserSummaryDTO getUserSummary(@PathVariable Long id) {
+        return userService.getUserSummary(id);
     }
 
     /**
@@ -67,6 +74,11 @@ public class UserController {
     @GetMapping("/all")
     public List<User> getAllUsers() {
         return userService.getAllUsers();
+    }
+
+    @GetMapping("/community-summary")
+    public CommunitySummaryDTO getCommunitySummary() {
+        return userService.getCommunitySummary();
     }
 
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/model/RewardItem.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/model/RewardItem.java
@@ -13,18 +13,15 @@ public class RewardItem {
     private String name;
     private String description;
     private int costPoints;
-    private String imageUrl;
 
     public RewardItem() {
     }
 
-    public RewardItem(Long id, String name, String description, int costPoints,
-                       String imageUrl) {
+    public RewardItem(Long id, String name, String description, int costPoints) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.costPoints = costPoints;
-        this.imageUrl = imageUrl;
     }
 
     public Long getId() {
@@ -57,13 +54,5 @@ public class RewardItem {
 
     public void setCostPoints(int costPoints) {
         this.costPoints = costPoints;
-    }
-
-    public String getImageUrl() {
-        return imageUrl;
-    }
-
-    public void setImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
     }
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/model/User.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/model/User.java
@@ -11,7 +11,6 @@ public class User {
     private Long id;
 
     private String username;
-    private String avatarUrl;
 
     private int dailyPoints;
     private int weeklyPoints;
@@ -24,12 +23,11 @@ public class User {
     public User() {
     }
 
-    public User(Long id, String username, String avatarUrl,
+    public User(Long id, String username,
                 int dailyPoints, int weeklyPoints, int totalPoints,
                 double dailyEnergy, double weeklyEnergy, double monthlyEnergy) {
         this.id = id;
         this.username = username;
-        this.avatarUrl = avatarUrl;
         this.dailyPoints = dailyPoints;
         this.weeklyPoints = weeklyPoints;
         this.totalPoints = totalPoints;
@@ -52,14 +50,6 @@ public class User {
 
     public void setUsername(String username) {
         this.username = username;
-    }
-
-    public String getAvatarUrl() {
-        return avatarUrl;
-    }
-
-    public void setAvatarUrl(String avatarUrl) {
-        this.avatarUrl = avatarUrl;
     }
 
     public int getDailyPoints() {

--- a/ESB-APP/src/main/java/com/esb/esbapp/service/UserService.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/service/UserService.java
@@ -1,5 +1,7 @@
 package com.esb.esbapp.service;
 
+import com.esb.esbapp.dto.CommunitySummaryDTO;
+import com.esb.esbapp.dto.UserSummaryDTO;
 import com.esb.esbapp.model.User;
 
 import java.util.List;
@@ -19,4 +21,8 @@ public interface UserService {
     String redeemReward(Long userId, Long rewardItemId);
 
     List<User> getAllUsers();
+
+    UserSummaryDTO getUserSummary(Long id);
+
+    CommunitySummaryDTO getCommunitySummary();
 }

--- a/ESB-APP/src/main/java/com/esb/esbapp/service/impl/UserServiceImpl.java
+++ b/ESB-APP/src/main/java/com/esb/esbapp/service/impl/UserServiceImpl.java
@@ -1,8 +1,10 @@
 package com.esb.esbapp.service.impl;
 
-import com.esb.esbapp.model.User;
-import com.esb.esbapp.model.Task;
+import com.esb.esbapp.dto.CommunitySummaryDTO;
+import com.esb.esbapp.dto.UserSummaryDTO;
 import com.esb.esbapp.model.RewardItem;
+import com.esb.esbapp.model.Task;
+import com.esb.esbapp.model.User;
 import com.esb.esbapp.repository.UserRepository;
 import com.esb.esbapp.repository.TaskRepository;
 import com.esb.esbapp.repository.RewardItemRepository;
@@ -91,5 +93,44 @@ public class UserServiceImpl implements UserService {
     @Override
     public List<User> getAllUsers() {
         return userRepository.findAll();
+    }
+
+    @Override
+    public UserSummaryDTO getUserSummary(Long id) {
+        User user = getUserById(id);
+        return new UserSummaryDTO(
+                user.getDailyPoints(),
+                user.getWeeklyPoints(),
+                user.getTotalPoints(),
+                user.getDailyEnergy(),
+                user.getWeeklyEnergy(),
+                user.getMonthlyEnergy()
+        );
+    }
+
+    @Override
+    public CommunitySummaryDTO getCommunitySummary() {
+        List<User> users = userRepository.findAll();
+        int count = users.size();
+        if (count == 0) {
+            return new CommunitySummaryDTO();
+        }
+
+        int sumDailyPoints = users.stream().mapToInt(User::getDailyPoints).sum();
+        int sumWeeklyPoints = users.stream().mapToInt(User::getWeeklyPoints).sum();
+        int sumTotalPoints = users.stream().mapToInt(User::getTotalPoints).sum();
+
+        double sumDailyEnergy = users.stream().mapToDouble(User::getDailyEnergy).sum();
+        double sumWeeklyEnergy = users.stream().mapToDouble(User::getWeeklyEnergy).sum();
+        double sumMonthlyEnergy = users.stream().mapToDouble(User::getMonthlyEnergy).sum();
+
+        return new CommunitySummaryDTO(
+                sumDailyPoints / count,
+                sumWeeklyPoints / count,
+                sumTotalPoints / count,
+                sumDailyEnergy / count,
+                sumWeeklyEnergy / count,
+                sumMonthlyEnergy / count
+        );
     }
 }

--- a/frontend/Screen/DashboardScreen.js
+++ b/frontend/Screen/DashboardScreen.js
@@ -15,8 +15,7 @@ import {
 
 import { BlurView } from 'expo-blur';
 
-// Temporarily use local mock data instead of calling the backend
-import { energyStats } from '../constants/mockStats';
+import { fetchEnergyStats } from '../service/api';
 import { Images } from '../assets';
 
 export default function DashboardScreen() {
@@ -26,9 +25,17 @@ export default function DashboardScreen() {
   const isWeb = Platform.OS === 'web';
   const Container = isWeb ? ScrollView : View;
 
-// For demo purposes, switch stats based on the selected mode without API calls
+// Fetch energy stats based on the selected mode
 useEffect(() => {
-  setStats(energyStats[mode]);
+  async function load() {
+    try {
+      const data = await fetchEnergyStats(mode, 1);
+      setStats(data);
+    } catch (e) {
+      console.error('Failed to fetch stats', e);
+    }
+  }
+  load();
 }, [mode]);
 
   // 翻转动画插值

--- a/frontend/Screen/LeaderboardScreen.js
+++ b/frontend/Screen/LeaderboardScreen.js
@@ -1,5 +1,5 @@
 // LeaderboardScreen.js
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import {
   View,
   Text,
@@ -11,8 +11,9 @@ import {
   Platform,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import { currentUser, leaderboardUsers } from '../constants/mockUsers';
+import { BASE_URL } from '../config';
 import { PointsContext } from '../context/PointsContext';
+import { leaderboardUsers } from '../constants/mockUsers';
 
 // 阶段 0、1 用同一张图片；阶段 2 用满分图片
 const CARD_IMAGES = [
@@ -35,6 +36,8 @@ export default function LeaderboardScreen() {
 
   // 排行榜顶部选项卡，可在 Day/Week/All 间切换
   const [selectedTab, setSelectedTab] = useState('Day');
+  const [listData, setListData] = useState([]);
+  const userId = 1;
 
   const isFull = taskProgress >= 2;
 
@@ -49,9 +52,27 @@ export default function LeaderboardScreen() {
       : selectedTab === 'Week'
       ? 'weeklyPoints'
       : 'totalPoints';
-  const listData = [currentUser, ...leaderboardUsers]
-    .slice(0, 10)
-    .sort((a, b) => (b[pointsField] || 0) - (a[pointsField] || 0));
+
+  useEffect(() => {
+    const fetchList = async () => {
+      const range =
+        selectedTab === 'Day' ? 'daily' : selectedTab === 'Week' ? 'weekly' : 'all';
+      try {
+        const res = await fetch(`${BASE_URL}/api/users/${userId}/leaderboard/${range}`);
+        if (res.ok) {
+          const data = await res.json();
+          const mapped = data.map((u, idx) => ({
+            ...u,
+            avatarUrl: leaderboardUsers[idx % leaderboardUsers.length].avatarUrl,
+          }));
+          setListData(mapped);
+        }
+      } catch (e) {
+        console.error('Failed to fetch leaderboard', e);
+      }
+    };
+    fetchList();
+  }, [selectedTab]);
 
   return (
     <ImageBackground
@@ -65,7 +86,7 @@ export default function LeaderboardScreen() {
           {/* 图片 + 文本：社区行 */}
           <View style={styles.communityRow}>
             <Image source={COMMUNITY_ICON} style={styles.communityIcon} />
-            <Text style={styles.communityText}>{currentUser.community}</Text>
+            <Text style={styles.communityText}>UCC Community</Text>
           </View>
 
           <View style={styles.pointRow}>

--- a/frontend/Screen/RewardsScreen.js
+++ b/frontend/Screen/RewardsScreen.js
@@ -1,5 +1,5 @@
 // RewardsScreen.js
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import {
   View,
   Text,
@@ -10,12 +10,34 @@ import {
   Platform,
 } from 'react-native';
 import RewardCard from '../components/RewardCard';
-import { rewardItems } from '../constants/mockRewards';
+import { fetchRewards } from '../service/api';
 import { PointsContext } from '../context/PointsContext';
+import { rewardItems as mockRewards } from '../constants/mockRewards';
 
 const RewardsScreen = () => {
   const isWeb = Platform.OS === 'web';
   const { points, deductPoints } = useContext(PointsContext);
+  const [rewards, setRewards] = useState([]);
+
+  useEffect(() => {
+    const loadRewards = async () => {
+      try {
+        const data = await fetchRewards();
+        const mapped = data.map((r) => {
+          const mock = mockRewards.find((m) => m.id === r.id);
+          return {
+            ...r,
+            costPoints: r.costPoints,
+            image: mock ? mock.image : null,
+          };
+        });
+        setRewards(mapped);
+      } catch (e) {
+        console.error('Failed to fetch rewards', e);
+      }
+    };
+    loadRewards();
+  }, []);
 
   const handleExchange = (item) => {
     if (points >= item.costPoints) {
@@ -46,7 +68,7 @@ const RewardsScreen = () => {
         <Text style={styles.header}>Exchange List</Text>
 
         <FlatList
-          data={rewardItems}
+          data={rewards}
           numColumns={2}
           keyExtractor={(item) => item.id.toString()}
           columnWrapperStyle={styles.row}

--- a/frontend/Screen/TasksScreen.js
+++ b/frontend/Screen/TasksScreen.js
@@ -1,5 +1,5 @@
 // TasksScreen.js
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -10,12 +10,39 @@ import {
   Platform,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import { taskList } from '../constants/mockTasks';
+import { fetchTasks } from '../service/api';
 import TaskCard from '../components/TaskCard';
 
 export default function TasksScreen() {
   const navigation = useNavigation();
-  const [tasks, setTasks] = useState(taskList);
+  const [tasks, setTasks] = useState([]);
+  const icons = [
+    require('../assets/Task/t1.png'),
+    require('../assets/Task/t2.png'),
+    require('../assets/Task/t3.png'),
+    require('../assets/Task/t4.png'),
+    require('../assets/Task/t5.png'),
+  ];
+
+  useEffect(() => {
+    const loadTasks = async () => {
+      try {
+        const data = await fetchTasks();
+        const mapped = data.map((t, i) => ({
+          id: t.id,
+          title: t.title,
+          description: t.description,
+          points: t.rewardPoints,
+          completed: false,
+          icon: icons[i % icons.length],
+        }));
+        setTasks(mapped);
+      } catch (e) {
+        console.error('Failed to fetch tasks', e);
+      }
+    };
+    loadTasks();
+  }, []);
 
   // 按“索引”完成，避免重复 id 影响到多条
   const handleCompleteAt = (index) => {

--- a/frontend/context/PointsContext.js
+++ b/frontend/context/PointsContext.js
@@ -1,5 +1,5 @@
-import React, { createContext, useState } from 'react';
-import { currentUser } from '../constants/mockUsers';
+import React, { createContext, useState, useEffect } from 'react';
+import { BASE_URL } from '../config';
 
 export const PointsContext = createContext({
   points: 0,
@@ -10,8 +10,25 @@ export const PointsContext = createContext({
 });
 
 export const PointsProvider = ({ children }) => {
-  const [points, setPoints] = useState(currentUser.dailyPoints || 0);
+  const [points, setPoints] = useState(0);
   const [taskProgress, setTaskProgress] = useState(0);
+  const userId = 1;
+
+  useEffect(() => {
+    async function loadPoints() {
+      try {
+        const res = await fetch(`${BASE_URL}/api/users/${userId}`);
+        if (res.ok) {
+          const data = await res.json();
+          setPoints(data.dailyPoints || 0);
+        }
+      } catch (e) {
+        console.error('Failed to fetch user info', e);
+      }
+    }
+
+    loadPoints();
+  }, []);
 
   const addPoints = (p = 0) => setPoints((v) => v + p);
   const deductPoints = (p = 0) => setPoints((v) => Math.max(0, v - p));

--- a/frontend/service/api.js
+++ b/frontend/service/api.js
@@ -1,15 +1,41 @@
 import { BASE_URL } from '../config';
 
 export async function fetchEnergyStats(mode, userId) {
-  const url = mode === 'home'
-    ? `${BASE_URL}/api/users/${userId}/summary`
-    : `${BASE_URL}/api/users/community-summary`;
+  if (mode === 'home') {
+    const res = await fetch(`${BASE_URL}/api/users/${userId}`);
+    if (!res.ok) throw new Error('Failed to fetch');
+    const data = await res.json();
+    return { used: data.monthlyEnergy, earned: data.totalPoints };
+  }
 
-  const res = await fetch(url);
+  const res = await fetch(`${BASE_URL}/api/users/all`);
   if (!res.ok) throw new Error('Failed to fetch');
-  const data = await res.json();
-  return {
-    used: data.monthlyEnergy,
-    earned: data.totalPoints,
-  };
+  const list = await res.json();
+  const used = list.reduce((sum, u) => sum + (u.monthlyEnergy || 0), 0);
+  const earned = list.reduce((sum, u) => sum + (u.totalPoints || 0), 0);
+  return { used, earned };
+}
+
+export async function fetchLeaderboard(type, userId) {
+  const res = await fetch(`${BASE_URL}/api/users/${userId}/leaderboard/${type}`);
+  if (!res.ok) throw new Error('Failed to fetch');
+  return await res.json();
+}
+
+export async function fetchRewards() {
+  const res = await fetch(`${BASE_URL}/api/rewards`);
+  if (!res.ok) throw new Error('Failed to fetch');
+  return await res.json();
+}
+
+export async function fetchTasks() {
+  const res = await fetch(`${BASE_URL}/api/tasks`);
+  if (!res.ok) throw new Error('Failed to fetch');
+  return await res.json();
+}
+
+export async function fetchUser(userId) {
+  const res = await fetch(`${BASE_URL}/api/users/${userId}`);
+  if (!res.ok) throw new Error('Failed to fetch');
+  return await res.json();
 }


### PR DESCRIPTION
## Summary
- fetch user points in context from backend
- load energy stats from backend
- load leaderboard, rewards and tasks from backend services
- update API helper with endpoints
- add user and community summary endpoints to the backend
- remove backend image URLs and map reward and leaderboard images from frontend mocks

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*
- `npm test` *(fails: Missing script `test`)*


------
https://chatgpt.com/codex/tasks/task_e_688d39915c10832ea0de50ba88005c87