### PR TITLE
Fix leaderboard avatar binding and fetch dashboard stats separately

### DIFF
--- a/frontend/Screen/DashboardScreen.js
+++ b/frontend/Screen/DashboardScreen.js
@@ -20,23 +20,28 @@ import { Images } from '../assets';
 
 export default function DashboardScreen() {
   const [mode, setMode] = useState('home');    // 'home' 或 'community'
-  const [stats, setStats] = useState(null);
+  const [homeStats, setHomeStats] = useState(null);
+  const [communityStats, setCommunityStats] = useState(null);
   const animated = useRef(new Animated.Value(0)).current;
   const isWeb = Platform.OS === 'web';
   const Container = isWeb ? ScrollView : View;
 
-// Fetch energy stats based on the selected mode
-useEffect(() => {
-  async function load() {
-    try {
-      const data = await fetchEnergyStats(mode, 1);
-      setStats(data);
-    } catch (e) {
-      console.error('Failed to fetch stats', e);
+  // 同时从后端获取两种模式的数据，确保正反面数据不同
+  useEffect(() => {
+    async function load() {
+      try {
+        const [homeData, communityData] = await Promise.all([
+          fetchEnergyStats('home', 1),
+          fetchEnergyStats('community', 1),
+        ]);
+        setHomeStats(homeData);
+        setCommunityStats(communityData);
+      } catch (e) {
+        console.error('Failed to fetch stats', e);
+      }
     }
-  }
-  load();
-}, [mode]);
+    load();
+  }, []);
 
   // 翻转动画插值
   const frontInterpol = animated.interpolate({
@@ -127,7 +132,7 @@ useEffect(() => {
                     <Image source={require('../assets/HomeScreen/lightning.png')} style={styles.pillIcon} />
                   </View>
                   <View style={styles.valueRow}>
-                    <Text style={styles.bigNumber}>{stats ? stats.used.toFixed(1) : '--'}</Text>
+                    <Text style={styles.bigNumber}>{homeStats ? homeStats.used.toFixed(1) : '--'}</Text>
                     <Text style={styles.unitText}> kWh</Text>
                   </View>
                   <Text style={styles.pillCaption}>Used</Text>
@@ -139,7 +144,7 @@ useEffect(() => {
                     <Image source={require('../assets/HomeScreen/star.png')} style={styles.pillIcon} />
                   </View>
                   <View style={styles.valueRow}>
-                    <Text style={styles.bigNumber}>{stats ? stats.earned : '--'}</Text>
+                    <Text style={styles.bigNumber}>{homeStats ? homeStats.earned : '--'}</Text>
                     <Text style={styles.unitText}> pts</Text>
                   </View>
                   <Text style={styles.pillCaption}>Earned</Text>
@@ -173,7 +178,7 @@ useEffect(() => {
                     <Image source={require('../assets/HomeScreen/lightning.png')} style={styles.pillIcon} />
                   </View>
                   <View style={styles.valueRow}>
-                    <Text style={styles.bigNumber}>{stats ? stats.used.toFixed(1) : '--'}</Text>
+                    <Text style={styles.bigNumber}>{communityStats ? communityStats.used.toFixed(1) : '--'}</Text>
                     <Text style={styles.unitText}> kWh</Text>
                   </View>
                   <Text style={styles.pillCaption}>Used</Text>
@@ -185,7 +190,7 @@ useEffect(() => {
                     <Image source={require('../assets/HomeScreen/star.png')} style={styles.pillIcon} />
                   </View>
                   <View style={styles.valueRow}>
-                    <Text style={styles.bigNumber}>{stats ? stats.earned : '--'}</Text>
+                    <Text style={styles.bigNumber}>{communityStats ? communityStats.earned : '--'}</Text>
                     <Text style={styles.unitText}> pts</Text>
                   </View>
                   <Text style={styles.pillCaption}>Earned</Text>

--- a/frontend/Screen/LeaderboardScreen.js
+++ b/frontend/Screen/LeaderboardScreen.js
@@ -13,7 +13,7 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import { BASE_URL } from '../config';
 import { PointsContext } from '../context/PointsContext';
-import { leaderboardUsers } from '../constants/mockUsers';
+import { currentUser, leaderboardUsers } from '../constants/mockUsers';
 
 // 阶段 0、1 用同一张图片；阶段 2 用满分图片
 const CARD_IMAGES = [
@@ -39,6 +39,14 @@ export default function LeaderboardScreen() {
   const [listData, setListData] = useState([]);
   const userId = 1;
 
+  // 将用户 id 与头像 url 建立映射，确保头像与用户名绑定
+  const avatarMap = React.useMemo(() => {
+    return [currentUser, ...leaderboardUsers].reduce((acc, u) => {
+      acc[u.id] = u.avatarUrl;
+      return acc;
+    }, {});
+  }, []);
+
   const isFull = taskProgress >= 2;
 
   const onPressComplete = () => {
@@ -61,9 +69,9 @@ export default function LeaderboardScreen() {
         const res = await fetch(`${BASE_URL}/api/users/${userId}/leaderboard/${range}`);
         if (res.ok) {
           const data = await res.json();
-          const mapped = data.map((u, idx) => ({
+          const mapped = data.map((u) => ({
             ...u,
-            avatarUrl: leaderboardUsers[idx % leaderboardUsers.length].avatarUrl,
+            avatarUrl: avatarMap[u.id] || DEFAULT_AVATAR,
           }));
           setListData(mapped);
         }


### PR DESCRIPTION
## Summary
- tie leaderboard avatars to specific users so avatars move with usernames
- load home and community energy stats separately for dashboard flip card

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688de335b548832e959dfaf961b5fc0a